### PR TITLE
fix: 다크모드의 요일 배경색 추가

### DIFF
--- a/components/WeeklySchedule.vue
+++ b/components/WeeklySchedule.vue
@@ -26,17 +26,17 @@ const dayOfTheWeekList = '일월화수목금토'.split('');
             :class="classNames(
               'px-4 py-1 text-center',
               {
-                'bg-red-300':
+                'bg-red-300 dark:bg-[#9e6a6a]':
                   extendedDay.isHoliday ||
                   ([SAT, SUN] as DayOfTheWeek[]).includes(extendedDay.dayOfTheWeek),
               },
               {
-                'bg-orange-300':
+                'bg-orange-300 dark:bg-[#9f774d]':
                   !extendedDay.isHoliday &&
                   ([FRI] as DayOfTheWeek[]).includes(extendedDay.dayOfTheWeek),
               },
               {
-                'bg-gray-300':
+                'bg-gray-300 dark:bg-[#84878a]':
                   !extendedDay.isHoliday &&
                   ([MON, TUE, WED, THU] as DayOfTheWeek[]).includes(extendedDay.dayOfTheWeek),
               },


### PR DESCRIPTION
fix #2 

색상 선정 방법:

- 다크모드 활성화 상태에서 요일 배경색에 opacity 60%를 주고, 눈에 보이는 색상을 color picker로 얻음